### PR TITLE
Trim xml before parsing

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]


### PR DESCRIPTION
Add code to trim xml before parsing, plus minor UI improvements.

"Cadence iPhone App" writes leading white space when exporting a TCX file and its output must be trimmed to be compatible with MSXML.  TcxPowerScaler would previously fail when trying to load a file like this and crash.  These updates trim the xml data before parsing.  Also when files cannot be parsed the program will notify the user, and move on to the next file in the list.